### PR TITLE
fix: only enable repos which require it

### DIFF
--- a/build-fix.sh
+++ b/build-fix.sh
@@ -2,8 +2,16 @@
 
 set -eoux pipefail
 
-sed -i "s@enabled=0@enabled=1@" /etc/yum.repos.d/fedora-updates.repo
-sed -i "s@enabled=0@enabled=1@" /etc/yum.repos.d/fedora-updates-archive.repo
+repos=(
+    fedora-updates.repo
+    fedora-updates-archive.repo
+)
+
+for repo in "${repos[@]}"; do
+    if [ $(grep -c "enabled=1" /etc/yum.repos.d/${repo}) -eq 0 ]; then
+        sed -i "0,/enabled=0/{s/enabled=0/enabled=1/}" /etc/yum.repos.d/${repo}
+    fi
+done
 
 rpm-ostree override replace \
     --experimental \

--- a/steam.sh
+++ b/steam.sh
@@ -2,7 +2,7 @@
 
 set -eoux pipefail
 
-sed -i "s@enabled=0@enabled=1@" /etc/yum.repos.d/negativo17-fedora-multimedia.repo
+sed -i "0,/enabled=0/{s/enabled=0/enabled=1/}" /etc/yum.repos.d/negativo17-fedora-multimedia.repo
 
 STEAM_PACKAGES=(
     clinfo


### PR DESCRIPTION
The loop for build-fix ensures that we only run a sed to enable the repo if it's not already enabled.

The changes to sed for build-fix and steam ensure that we only enable the first repo defined in a specified repo file .