### PR TITLE
fix: remove evolution

### DIFF
--- a/build_files/desktop-packages.sh
+++ b/build_files/desktop-packages.sh
@@ -85,7 +85,7 @@ install -m 0755 /tmp/ghostty.appimage /usr/bin/ghostty
 
 # Sysexts
 mkdir -p /usr/lib/sysupdate.d
-SYSEXTS=(emacs evolution)
+SYSEXTS=(emacs)
 for s in "${SYSEXTS[@]}"; do
     tee /usr/lib/sysupdate.d/"$s".transfer <<EOF
 [Transfer]


### PR DESCRIPTION
evolution requires compiling gschema which doesn't appear feasible with sysexts